### PR TITLE
fix(frontend): listen on IPv6 so the container healthcheck passes

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    listen [::]:80;
     server_name _;
 
     root /usr/share/nginx/html;


### PR DESCRIPTION
## Problem
The `frontend` container reports `(unhealthy)` out of the box, even though it serves requests fine (HTTP 200). Full analysis in #18.

`Dockerfile.frontend` removes `default.conf` and copies the app config as `ourschool.conf`, so the base `nginx:alpine` image's `10-listen-on-ipv6-by-default.sh` no-ops and nginx listens on `0.0.0.0:80` (IPv4) only. The container healthcheck (`wget -qO- http://localhost:80`) resolves `localhost` to `::1` (IPv6) first, can't connect, and marks the container unhealthy.

## Fix
Add `listen [::]:80;` to `nginx.conf` so nginx is dual-stack. The existing `localhost` healthcheck then connects over IPv6, and IPv6 clients are served too. One line, no compose changes.

## Testing
Verified in a running container: after the change, `wget -qO- http://localhost:80` returns exit 0 and the container reports `healthy`; IPv4 access is unaffected.

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)
