### PR TITLE
Fix inconsistent padding in Attendance & compliance settings card

### DIFF
--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -838,8 +838,8 @@ const Admin: React.FC = () => {
       case 'attendance': return (
         <div>
           <SectionHeader title="Attendance & compliance" desc="Set the instructional-day target used for compliance." />
-          <div className="bg-panel border border-line rounded-card divide-y divide-line-2">
-            <div className="p-5">
+          <div className="bg-panel border border-line rounded-card divide-y divide-line-2 px-5">
+            <div className="py-5">
               <p className="text-[13.5px] font-medium text-ink mb-0.5">Required days of instruction</p>
               <p className="text-[12px] text-muted mb-3">Used for compliance tracking. Most jurisdictions require 160–200 days per year.</p>
               <div className="flex items-center gap-3">


### PR DESCRIPTION
Fixes #23

## Problem

On **Settings → Attendance & compliance**, the `SettingRow` toggle rows ("Skip weekends", "Count excused days") sit flush against the card edges while the "Required days" block above them is inset — they look misaligned.

## Cause

`SettingRow` carries vertical padding only (`py-4`) and depends on its parent card for horizontal padding. The **Points & rewards** card supplies `px-5`; the **Attendance & compliance** card does not, so its rows get no horizontal inset — while the "Required days" block does, via its own `p-5`.

## Change

Mirror the Points & rewards card: add `px-5` to the Attendance card wrapper and change the first block from `p-5` to `py-5` (parent now supplies the horizontal padding). All three rows now share one consistent 20px inset. Two-line CSS-class change, no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)