### PR TITLE
Preserve point transaction dates during backup restore

### DIFF
--- a/app/routers/backup/importers.py
+++ b/app/routers/backup/importers.py
@@ -1115,6 +1115,7 @@ def _import_point_transactions(db: Session, point_transactions_data, result, dry
                 transaction_type=tx_data.transaction_type,
                 source_description=tx_data.source_description,
                 notes=tx_data.notes,
+                created_at=tx_data.created_at,
             )
             db.add(new_tx)
             db.flush()

--- a/tests/test_backup_roundtrip.py
+++ b/tests/test_backup_roundtrip.py
@@ -5,6 +5,8 @@ external_id, then natural keys) and skipped/updated; deleted records are
 recreated from the backup. That restore path is what these tests exercise.
 """
 
+from datetime import datetime, timezone
+
 
 def _export(client, admin_headers):
     r = client.get("/api/backup/export", headers=admin_headers)
@@ -241,6 +243,54 @@ def test_wipe_and_restore_replaces_data_and_preserves_admin(
         .first()
         is not None
     )
+
+
+def test_wipe_restore_preserves_point_transaction_dates(
+    client, admin_headers, student_factory, db_session
+):
+    from app.models.points import PointTransaction
+
+    student, _ = student_factory()
+    r = client.post(
+        "/api/points/adjust",
+        json={"student_id": student["id"], "amount": 25, "notes": "Reading goal"},
+        headers=admin_headers,
+    )
+    assert r.status_code == 200, r.text
+
+    original_created_at = datetime(2025, 1, 15, 16, 30, tzinfo=timezone.utc)
+    transaction = db_session.query(PointTransaction).filter_by(id=r.json()["id"]).one()
+    transaction.created_at = original_created_at
+    db_session.commit()
+
+    backup = _export(client, admin_headers)
+    r = client.post(
+        "/api/backup/import",
+        json={
+            "backup_data": backup,
+            "import_options": {"wipe_before_import": True},
+            "wipe_confirmation": "WIPE ALL DATA",
+        },
+        headers=admin_headers,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["success"] is True, r.json()
+
+    r = client.get("/api/users/students", headers=admin_headers)
+    assert r.status_code == 200, r.text
+    restored_student = next(
+        candidate for candidate in r.json() if candidate["email"] == student["email"]
+    )
+
+    r = client.get(
+        f"/api/points/student/{restored_student['id']}/ledger",
+        headers=admin_headers,
+    )
+    assert r.status_code == 200, r.text
+    restored_created_at = datetime.fromisoformat(
+        r.json()["transactions"][0]["created_at"].replace("Z", "+00:00")
+    )
+    assert restored_created_at == original_created_at
 
 
 def test_wipe_rolls_back_fully_on_import_failure(


### PR DESCRIPTION
## Summary

- preserve each point transaction's archived `created_at` value during backup import
- add an end-to-end wipe-and-restore regression test that verifies the restored ledger timestamp

## Root cause

The exporter included `PointTransaction.created_at`, and the importer used that value for deduplication, but the new restored row never received it. PostgreSQL therefore applied the column's `now()` default and made every restored transaction look newly created.

## Small, cohesive steps

1. `b237a06` — map the archived timestamp onto restored point transactions
2. `60daf46` — cover export → wipe → import → ledger with a regression test

## Validation

- `pytest` — all 86 backend tests pass
- `pytest tests/test_backup_roundtrip.py::test_wipe_restore_preserves_point_transaction_dates -vv --disable-warnings`
- `ruff check app`
- `black --check app`
- `vulture app --min-confidence 80 --ignore-names cls`
- `alembic upgrade head`
- frontend type-check, 5 tests, lint, Knip, and production build
- backend and frontend Docker image builds

## Screenshot proof

The named regression restores a transaction archived at `2025-01-15 16:30:00 UTC` and verifies that the ledger returns the same timestamp.

![Passing point transaction date restore regression test](https://files.catbox.moe/odhrai.png)

Fixes #25
