### PR TITLE
Scope student dashboard stats to active term

### DIFF
--- a/app/crud/reports/overview.py
+++ b/app/crud/reports/overview.py
@@ -63,18 +63,30 @@ def get_student_report(db: Session, student_id: int):
         .options(joinedload(StudentAssignment.template))
         .all()
     )
+    active_term = db.query(Term).filter(Term.is_active).first()
+    term_assignments = (
+        [
+            assignment
+            for assignment in assignments
+            if active_term.start_date
+            <= effective_due_date(assignment)
+            <= active_term.end_date
+        ]
+        if active_term
+        else []
+    )
 
     type_weights = crud_settings.get_assignment_type_weights(db)
 
-    total_assignments = len(assignments)
+    total_assignments = len(term_assignments)
     completed_assignments = sum(
-        1 for a in assignments if a.status == AssignmentStatus.GRADED
+        1 for a in term_assignments if a.status == AssignmentStatus.GRADED
     )
     in_progress_assignments = sum(
-        1 for a in assignments if a.status == AssignmentStatus.IN_PROGRESS
+        1 for a in term_assignments if a.status == AssignmentStatus.IN_PROGRESS
     )
     pending_grades = sum(
-        1 for a in assignments if a.status == AssignmentStatus.SUBMITTED
+        1 for a in term_assignments if a.status == AssignmentStatus.SUBMITTED
     )
 
     graded_assignments = [a for a in assignments if _is_graded(a)]
@@ -83,16 +95,11 @@ def get_student_report(db: Session, student_id: int):
     )
 
     # Current term grade (assignments whose effective due date falls in the term)
-    active_term = db.query(Term).filter(Term.is_active).first()
     current_term_grade = 0.0
     if active_term:
-        term_assignments = [
-            a
-            for a in graded_assignments
-            if active_term.start_date <= effective_due_date(a) <= active_term.end_date
-        ]
+        graded_term_assignments = [a for a in term_assignments if _is_graded(a)]
         _, _, current_term_grade = compute_weighted_grade(
-            (_grade_item(a) for a in term_assignments), type_weights
+            (_grade_item(a) for a in graded_term_assignments), type_weights
         )
 
     grade_series = _build_weekly_series(graded_assignments, type_weights, active_term)

--- a/tests/test_student_dashboard.py
+++ b/tests/test_student_dashboard.py
@@ -1,0 +1,88 @@
+"""Student dashboard reporting tests."""
+
+
+def _set_status(client, headers, assignment_id, status):
+    response = client.put(
+        f"/api/assignments/student-assignments/{assignment_id}",
+        json={"status": status},
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+
+
+def _grade(client, headers, assignment_id, points):
+    response = client.post(
+        f"/api/assignments/student-assignments/{assignment_id}/grade",
+        json={"points_earned": points},
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_student_dashboard_stats_only_include_active_term_assignments(
+    client, admin_headers, classroom, student_factory, assign
+):
+    student, student_headers = student_factory()
+
+    response = client.post(
+        "/api/terms/",
+        json={
+            "name": "Prior term",
+            "start_date": "2025-01-06",
+            "end_date": "2025-06-06",
+            "academic_year": "2024-2025",
+        },
+        headers=admin_headers,
+    )
+    assert response.status_code == 200, response.text
+
+    current_graded = assign(
+        classroom["template"]["id"], student["id"], due_date="2026-03-01"
+    )
+    current_in_progress = assign(
+        classroom["template"]["id"], student["id"], due_date="2026-04-01"
+    )
+    current_submitted = assign(
+        classroom["template"]["id"], student["id"], due_date="2026-05-01"
+    )
+
+    historical_graded = assign(
+        classroom["template"]["id"],
+        student["id"],
+        assigned_date="2025-02-01",
+        due_date="2025-03-01",
+    )
+    historical_in_progress = assign(
+        classroom["template"]["id"],
+        student["id"],
+        assigned_date="2025-02-01",
+        due_date="2025-04-01",
+    )
+    historical_submitted = assign(
+        classroom["template"]["id"],
+        student["id"],
+        assigned_date="2025-02-01",
+        due_date="2025-05-01",
+    )
+
+    _grade(client, admin_headers, current_graded["id"], 80)
+    _set_status(
+        client, student_headers, current_in_progress["id"], "in_progress"
+    )
+    _set_status(client, student_headers, current_submitted["id"], "submitted")
+
+    _grade(client, admin_headers, historical_graded["id"], 100)
+    _set_status(
+        client, student_headers, historical_in_progress["id"], "in_progress"
+    )
+    _set_status(client, student_headers, historical_submitted["id"], "submitted")
+
+    response = client.get("/api/reports/student/overview", headers=student_headers)
+    assert response.status_code == 200, response.text
+    report = response.json()
+
+    assert report["total_assignments"] == 3
+    assert report["completed_assignments"] == 1
+    assert report["in_progress_assignments"] == 1
+    assert report["pending_grades"] == 1
+    assert report["current_term_grade"] == 80


### PR DESCRIPTION
## Summary

- scope student dashboard assignment counters to the currently active academic term
- preserve the existing all-time grade calculation while reusing the term-scoped assignment set for the current-term grade
- add an API-level regression test covering graded, in-progress, and submitted work across active and historical terms

## Root cause

`get_student_report` loaded every assignment for the student and used that full historical collection for the dashboard summary counters. Although the current-term grade already applied term dates, the assignment, completed, in-progress, and pending counts did not.

## Small, cohesive steps

1. `063c4f6` — calculate student dashboard counters from active-term assignments
2. `755ede8` — cover active and historical assignment statuses end to end

## Validation

- `pytest` — all 86 backend tests pass
- `pytest tests/test_student_dashboard.py::test_student_dashboard_stats_only_include_active_term_assignments -vv --disable-warnings`
- `ruff check app`
- `black --check app`
- `vulture app --min-confidence 80 --ignore-names cls`
- `alembic upgrade head`
- frontend type-check, 5 tests, lint, Knip, and production build
- backend and frontend Docker image builds

## Screenshot proof

The regression creates three active-term and three historical assignments across graded, in-progress, and submitted states, then verifies that the dashboard reports only the active term's three.

![Passing active-term student dashboard regression test](https://files.catbox.moe/xscgn4.png)

Fixes #26
